### PR TITLE
fix subtle flickers due to ui thread reading partially rendered framebuffers

### DIFF
--- a/src/common/video_device.h
+++ b/src/common/video_device.h
@@ -6,7 +6,7 @@ namespace common {
 
 struct VideoDevice {
     virtual ~VideoDevice() = default;
-    virtual void update_texture() = 0;
+    virtual void update_texture(u32* pointer) = 0;
     virtual void destroy() = 0;
 };
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -166,6 +166,10 @@ void System::run_frame() {
     //     scheduler.tick(cycles);
     //     scheduler.run();
     // }
+
+    // TODO: move this to VideoUnit when hblank or end of frame occurs
+    video_unit.ppu_a.on_finish_frame();
+    video_unit.ppu_b.on_finish_frame();
 }
 
 void System::direct_boot() {

--- a/src/core/video/ppu/ppu.h
+++ b/src/core/video/ppu/ppu.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <mutex>
 #include "common/types.h"
 #include "common/callback.h"
 #include "core/video/vram_region.h"
@@ -40,7 +41,8 @@ public:
     void write_bldy(u16 value, u32 mask);
     void write_master_bright(u32 value, u32 mask);
 
-    void submit_framebuffer(u32* target);
+    u32* fetch_framebuffer();
+    void on_finish_frame();
     
 private:
     using AffineCallback = common::Callback<void(int pixel, int x, int y), 40>;
@@ -231,6 +233,8 @@ private:
     int mosaic_bg_vertical_counter;
 
     std::array<u32, 256 * 192> framebuffer;
+    std::array<u32, 256 * 192> converted_framebuffer;
+    std::mutex converted_framebuffer_mutex;
     std::array<std::array<u16, 256>, 4> bg_layers;
     std::array<Object, 256> obj_buffer;
     

--- a/src/core/video/video_unit.cpp
+++ b/src/core/video/video_unit.cpp
@@ -71,11 +71,11 @@ void VideoUnit::write_dispcapcnt(u32 value, u32 mask) {
     }
 }
 
-void VideoUnit::submit_framebuffer(Screen screen, u32* target) {
+u32* VideoUnit::fetch_framebuffer(Screen screen) {
     if (powcnt1.display_swap == (screen == Screen::Top)) {
-        ppu_a.submit_framebuffer(target);
+        return ppu_a.fetch_framebuffer();
     } else {
-        ppu_b.submit_framebuffer(target);
+        return ppu_b.fetch_framebuffer();
     }
 }
 

--- a/src/core/video/video_unit.h
+++ b/src/core/video/video_unit.h
@@ -35,7 +35,7 @@ public:
     void write_powcnt1(u16 value, u32 mask);
     void write_dispcapcnt(u32 value, u32 mask);
 
-    void submit_framebuffer(Screen screen, u32* target);
+    u32* fetch_framebuffer(Screen screen);
 
     u8* get_palette_ram() { return palette_ram.data(); }
     u8* get_oam() { return oam.data(); }

--- a/src/frontend/application.cpp
+++ b/src/frontend/application.cpp
@@ -133,10 +133,8 @@ void Application::handle_input() {
 }
 
 void Application::render_screens() {
-    system.video_unit.submit_framebuffer(core::Screen::Top, top_screen.get_framebuffer());
-    system.video_unit.submit_framebuffer(core::Screen::Bottom, bottom_screen.get_framebuffer());
-    top_screen.update_texture();
-    bottom_screen.update_texture();
+    top_screen.update_texture(system.video_unit.fetch_framebuffer(core::Screen::Top));
+    bottom_screen.update_texture(system.video_unit.fetch_framebuffer(core::Screen::Bottom));
 
     const f64 scale_x = static_cast<f64>(window_width) / 256;
     const f64 scale_y = static_cast<f64>(window_height) / 384;

--- a/src/frontend/imgui_video_device.cpp
+++ b/src/frontend/imgui_video_device.cpp
@@ -1,12 +1,8 @@
 #include "frontend/imgui_video_device.h"
 
-ImGuiVideoDevice::ImGuiVideoDevice() {
-    framebuffer.fill(0x00000000);
-}
-
-void ImGuiVideoDevice::update_texture() {
+void ImGuiVideoDevice::update_texture(u32* pointer) {
     glBindTexture(GL_TEXTURE_2D, texture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, framebuffer.data());
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pointer);
 }
 
 void ImGuiVideoDevice::destroy() {

--- a/src/frontend/imgui_video_device.h
+++ b/src/frontend/imgui_video_device.h
@@ -7,22 +7,18 @@
 
 class ImGuiVideoDevice : public common::VideoDevice {
 public:
-    ImGuiVideoDevice();
-
     enum class Filter {
         Nearest,
         Linear,
     };
 
-    void update_texture() override;
+    void update_texture(u32* pointer) override;
     void destroy() override;
     void configure(int width, int height, Filter filter);
 
     GLuint get_texture() { return texture; }
-    u32* get_framebuffer() { return framebuffer.data(); }
-
+    
 private:
-    std::array<u32, 256 * 192> framebuffer;
     GLuint texture;
     int width;
     int height;


### PR DESCRIPTION
This PR fixes issues where the ui thread was able to fetch the ppu framebuffers at any given time, where potentially only part of the scanlines had been rendered. Although this wasn't usually an issue, sometimes subtle flickers could occur. To resolve this the following has been done:

- Keep a separate framebuffer copy which is only updated when a frame ends in the emulator thread
- lock on a mutex when accessing the converted framebuffer from both the emulator and ui thread